### PR TITLE
Fix Android Studio link

### DIFF
--- a/docs/emulator_guide.md
+++ b/docs/emulator_guide.md
@@ -6,7 +6,7 @@ device with Android Studio. After creating an AVD
 you will be able to connect it to an AndroidEnv instance and you're ready to go.
 
 To get started, you will need to download
-[Android Studio](https://developer.android.com/android-studio/download), a
+[Android Studio](https://developer.android.com/studio), a
 software widely used by Android developers.
 
 ## Install an SDK Platform Package


### PR DESCRIPTION
The old link takes you to a 404, the link in the PR takes you to https://developer.android.com/studio which should fix it.