### PR TITLE
AndroidEnv instructions: add code examples/update/lint to help users get started faster

### DIFF
--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -6,15 +6,15 @@ following sections you will learn how you can create them.
 
 ### The simulator
 
-First, you will need to provide your Android virtual device (AVD) that
-environment (and through it, the agent) to communicate with. While this can also
+First, you will need to provide your Android virtual device (AVD) that the
+environment (and through it, the agent) can communicate with. While this can also
 be a physical device, in most cases you will need a virtual emulated device.
-There are many ways to emulate an AVD. In our examples, we will use
+There are many ways to emulate an AVD - in our examples, we will use
 [Android Studio](https://developer.android.com/studio) to create one.
 
 1. In Android Studio, create a virtual device by following this step-by-step
 [guide](emulator_guide.md).
-2. Follow the steps below to attach the ADV to your environment.
+2. Follow the steps below to attach the AVD to your environment.
 
 ### The task and examples with games and other apps
 

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -2,52 +2,59 @@
 
 In order to create an AndroidEnv instance you will need to provide two main
 components: a [simulator](#the-simulator) and a [task](#the-task). In the
-following sections we will provide information about how you can create these.
+following sections you will learn how you can create them.
 
 ### The simulator
 
-First, you will need to provide an Android device that environment (and through
-it, the agent) can communicate with. While this could be a real device as well,
-in most cases you will want to use a virtual, emulated device. There are many
-ways to simulate such a device; in our example we will use
-[Android Studio](https://developer.android.com/studio) to create one. Follow
-this step-by-step [guide](emulator_guide.md) to create a virtual device, then
-follow the steps below to attach this to your environment.
+First, you will need to provide your Android virtual device (AVD) that
+environment (and through it, the agent) to communicate with. While this can also
+be a physical device, in most cases you will need a virtual emulated device.
+There are many ways to emulate an AVD. In our examples, we will use
+[Android Studio](https://developer.android.com/studio) to create one.
 
-### The task
+1. In Android Studio, create a virtual device by following this step-by-step
+[guide](emulator_guide.md).
+2. Follow the steps below to attach the ADV to your environment.
+
+### The task and examples with games and other apps
 
 A `task` is a particular definition of an RL problem that the agent will be
-interacting with. A `task` might include critical RL information such as what
-are the rewards, when are episodes supposed to terminate, and what reset
-procedures the environment should perform upon episode termination (e.g. start
-or relaunch an app, clear cache etc.). These information are packaged into a
-`Task()` proto message which gets passed passed to AndroidEnv. Please see
-[tasks_guide.md](tasks_guide.md) for details on features and capabilities of
-tasks, as well as how to create custom ones; or use one of our example tasks
-provided in [example_tasks.md](example_tasks.md).
+interacting with. A `task` may include critical RL information, such as what the
+rewards are, when the episodes are supposed to terminate, and what the reset
+procedures are that the environment should perform upon episode termination
+(e.g. start or relaunch an app, clear cache, etc.). This information is packaged
+into a `Task()` proto message, which gets passed passed to AndroidEnv.
 
-### Create the env
+* For ready-made example tasks provided with AndroidEnv, check out
+  the [Available tasks](example_tasks.md), featuring Vokram (with Markov Decision
+  Process (MDP)), Pong, DroidFish (a chess clone), Blockinger (a tetris clone),
+  and more.
 
-After setting up the simulator and creating a task, you might find that
-`android_env.load()` function is a handy tool for creating an env instance, once
-you provide the relevant arguments:
+* See the [Tasks guide](tasks_guide.md) for details on features and
+  capabilities of tasks, as well as how to create custom ones.
 
-*   `task_path`: path pointing to the `.textproto` file describing the desired
-    task.
-*   `avd_name`: the name of the AVD specified when the AVD was created in
-    Android Studio.
-*   `android_avd_home` (Optional): Path where the AVD was installed. Defaults to
-    `~/.android/avd`.
-*   `android_sdk_root` (Optional): Root directory of the Android SDK. Defaults
-    to `~/Android/Sdk`.
-*   `emulator_path` (Optional): Path to the emulator binary. Defaults to
-    `~/Android/Sdk/emulator/emulator`.
-*   `adb_path` (Optional): Path to the ADB
+### Create the environment
+
+After setting up the simulator and creating a task, you may find the 
+`android_env.load()` function handy for creating an environment instance by
+providing relevant arguments, such as:
+
+*   `task_path`: the path pointing to the `.textproto` file describing the
+    desired task.
+*   `avd_name`: the name of the AVD specified when your created it in Android
+    Studio.
+*   `android_avd_home` (Optional): the path to where the AVD is installed. 
+    (default value: `~/.android/avd`).
+*   `android_sdk_root` (Optional): thr root directory of the Android SDK. 
+    (default value: `~/Android/Sdk`).
+*   `emulator_path` (Optional): the path to the emulator binary. (default:
+    `~/Android/Sdk/emulator/emulator`).
+*   `adb_path` (Optional): the path to the ADB
     ([Android Debug Bridge](https://developer.android.com/studio/command-line/adb)).
-    Defaults to `~/Android/Sdk/platform-tools/adb`.
+    (default valye: `~/Android/Sdk/platform-tools/adb`).
 
-Thus an example configuration might look like (depending on how you set up your
-emulator):
+Your example configuration may look like, depending on how you set up your
+emulator:
 
 ```python
 import android_env
@@ -62,16 +69,18 @@ env = android_env.load(
 )
 ```
 
-## Example scripts
+## Example RL agent scripts
 
-See our `examples` directory a few simple example agent setups.
+The `examples` directory contains a few simple example agent setups, such as:
 
-*   `run_random_agent.py`: Runs a simple loop performing randomly selected
-    actions in the environment.
-*   `run_acme_agent.py`: Runs a training loop with an acme DQN agent,
-    implemented in the popular DeepMind RL framework. This will require that the
-    optional depenecy [acme](https://github.com/deepmind/acme) is installed.
-*   `run_human_agent.py`: Creates a `pygame` instance that lets a human user
-    interact with the environment and observe environment mechanics such as
-    rewards or task extras. This will require that the optional depenecy
-    [pygame](https://www.pygame.org/wiki/GettingStarted) is installed.
+*   [`run_random_agent.py`](https://github.com/deepmind/android_env/blob/main/examples/run_random_agent.py):
+    Runs a simple loop performing randomly selected actions in the environment.
+*   [`run_acme_agent.py`](https://github.com/deepmind/android_env/blob/main/examples/run_acme_agent.py):
+    Runs a training loop with an [Acme](https://deepmind.com/research/publications/Acme)
+    DQN agent, implemented in the popular DeepMind RL framework. This will
+    require to install the [`acme`](https://github.com/deepmind/acme)
+    dependency.
+*   [`run_human_agent.py`](https://github.com/deepmind/android_env/blob/main/examples/run_human_agent.py):
+    Creates a [`pygame`](https://www.pygame.org) instance that lets a human user
+    interact with the environment and observe environment mechanics, such as
+    rewards or task extras. You will need to install the [PyGame] dependency.

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -60,7 +60,7 @@ For the AVD name and path, in Android Studio, go to **Tools** >
 
 For the Android SDK location, in Android Studio, go to **Preferences** >
 **Appearance & Behavior** > **System Settings** > **Android SDKs** and note the
-_Android SDK Location_.  In the SDK folder, you will find `/emulator/emulator`
+_Android SDK Location_. In the SDK folder, you will find `/emulator/emulator`
 as well as the ADB path (`/platform-tools/adb`).
 
 Your example configuration may look like this, depending on how you set up your
@@ -94,3 +94,24 @@ The `examples` directory contains a few simple example agent setups, such as:
     Creates a [`pygame`](https://www.pygame.org) instance that lets a human user
     interact with the environment and observe environment mechanics, such as
     rewards or task extras. You will need to install the [PyGame] dependency.
+
+For instance, here is how you can run `run_random_agent.py` in a folder where
+you have your APK file, such as
+the [Apple Flinger](https://github.com/deepmind/android_env/blob/main/docs/example_tasks.md#apple-flinger)
+game.
+(You can find the TAR file with the APK and `.textproto` files
+[here](https://storage.googleapis.com/android_env-tasks/apple_flinger.tar.gz)
+and on the
+[example tasks](https://github.com/deepmind/android_env/blob/main/docs/example_tasks.md)
+page.)
+
+```shell
+python3 run_random_agent.py \
+--avd_name='my_avd',
+--android_avd_home=/Users/username/.android/avd \
+--android_sdk_root=/Users/username/Library/Android/sdk \
+--emulator_path=/Users/username/Library/Android/sdk/emulator/emulator \
+--adb_path=/Users/username/Library/Android/sdk/platform-tools/adb \
+--num_steps=1000 \
+--task_path=/Users/username/<PATH-TO-APPLE-FLINGER-FILES>/apple_flinger_M_1_1.textproto
+```

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -45,15 +45,24 @@ providing relevant arguments, such as:
     Studio.
 *   `android_avd_home` (Optional): the path to where the AVD is installed. 
     (default value: `~/.android/avd`).
-*   `android_sdk_root` (Optional): thr root directory of the Android SDK. 
+*   `android_sdk_root` (Optional): the root directory of the Android SDK. 
     (default value: `~/Android/Sdk`).
 *   `emulator_path` (Optional): the path to the emulator binary. (default:
     `~/Android/Sdk/emulator/emulator`).
 *   `adb_path` (Optional): the path to the ADB
     ([Android Debug Bridge](https://developer.android.com/studio/command-line/adb)).
     (default value: `~/Android/Sdk/platform-tools/adb`).
+ 
+For the AVD name and path, in Android Studio, go to **Tools** >
+**AVD Manager**, right click on your virtual device, and select
+**View Details**, where you will find the `avd_name` and its path.
 
-Your example configuration may look like, depending on how you set up your
+For the Android SDK location, in Android Studio, go to **Preferences** >
+**Appearance & Behavior** > **System Settings** > **Android SDKs** and note the
+_Android SDK Location_.  In the SDK folder, you will find `/emulator/emulator`
+as well as the ADB path (`/platform-tools/adb`).
+
+Your example configuration may look like this, depending on how you set up your
 emulator:
 
 ```python

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -36,8 +36,9 @@ into a `Task()` proto message, which gets passed passed to AndroidEnv.
 ### Create the environment
 
 After setting up the simulator and creating a task, you may find the 
-`android_env.load()` function handy for creating an environment instance by
-providing relevant arguments, such as:
+[`android_env.load()`](https://github.com/deepmind/android_env/blob/main/android_env/loader.py)
+function handy for creating an environment instance by providing relevant
+arguments, such as:
 
 *   `task_path`: the path pointing to the `.textproto` file describing the
     desired task.

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -97,9 +97,9 @@ The `examples` directory contains a few simple example agent setups, such as:
 
 For instance, here is how you can run
 [`run_random_agent.py`](https://github.com/8bitmp3/android_env/blob/main/examples/run_random_agent.py)
-in a folder where you have your APK file, such as the
+in a folder where you have your APK file, such as
 [Apple Flinger](https://github.com/deepmind/android_env/blob/main/docs/example_tasks.md#apple-flinger)
-game from
+from
 [Example tasks](https://github.com/deepmind/android_env/blob/main/docs/example_tasks.md).
 (The downloaded TAR file contains the APK file and `.textproto` definitions.)
 

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -115,3 +115,58 @@ python3 run_random_agent.py \
 --num_steps=1000 \
 --task_path=/Users/username/<PATH-TO-APPLE-FLINGER-FILES>/apple_flinger_M_1_1.textproto
 ```
+
+## Example with code: a random agent playing Droidfish (chess)
+
+Below is an example of a random agent playing chess in Droidfish using
+`droidfish_black_1.textproto` over 1000 steps (where `1` indicates the
+[level of difficulty](https://github.com/deepmind/android_env/blob/main/docs/example_tasks.md#droidfish)).
+You need to execute the Python code in a folder where you have the Droidfish APK
+file. (Download the Droidfish TAR file with the APK and `.textproto` files
+[here](https://storage.googleapis.com/android_env-tasks/droidfish.tar.gz)
+and on the
+[example tasks](https://github.com/deepmind/android_env/blob/main/docs/example_tasks.md)
+page.) Notice the use of `dm_env` - it's the
+[DeepMind RL Environment API](https://github.com/deepmind/dm_env).
+
+```python
+import android_env
+from dm_env import specs
+import numpy as np
+from typing import Dict
+
+env = android_env.load(
+    avd_name='my_avd',
+    android_avd_home='/Users/username/.android/avd',
+    android_sdk_root='/Users/username/Library/Android/sdk',
+    emulator_path='/Users/username/Library/Android/sdk/emulator/emulator',
+    adb_path='/Users/username/Library/Android/sdk/platform-tools/adb',
+    emulator_path='/Users/username/Library/Android/sdk/emulator/emulator',
+    adb_path='/Users/username/Library/Android/sdk/platform-tools/adb',
+    task_path='~/<path-to-droidfish-textproto>/droidfish_black_1.textproto'
+)
+
+action_spec = env.action_spec()
+
+def get_random_action() -> Dict[str, np.ndarray]:
+  """Returns a random AndroidEnv action."""
+  action = {}
+  for k, v in action_spec.items():
+    if isinstance(v, specs.DiscreteArray):
+      action[k] = np.random.randint(low=0, high=v.num_values, dtype=v.dtype)
+    else:
+      action[k] = np.random.random(size=v.shape).astype(v.dtype)
+  return action
+
+_ = env.reset()
+
+STEPS = 1000
+
+for step in range(STEPS):
+  action = get_random_action()
+  timestep = env.step(action=action)
+  reward = timestep.reward
+  print('Step {}, action: {}, reward: {}'.format(step, action, reward))
+
+env.close()
+```

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -51,7 +51,7 @@ providing relevant arguments, such as:
     `~/Android/Sdk/emulator/emulator`).
 *   `adb_path` (Optional): the path to the ADB
     ([Android Debug Bridge](https://developer.android.com/studio/command-line/adb)).
-    (default valye: `~/Android/Sdk/platform-tools/adb`).
+    (default value: `~/Android/Sdk/platform-tools/adb`).
 
 Your example configuration may look like, depending on how you set up your
 emulator:

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -95,15 +95,13 @@ The `examples` directory contains a few simple example agent setups, such as:
     interact with the environment and observe environment mechanics, such as
     rewards or task extras. You will need to install the [PyGame] dependency.
 
-For instance, here is how you can run `run_random_agent.py` in a folder where
-you have your APK file, such as
-the [Apple Flinger](https://github.com/deepmind/android_env/blob/main/docs/example_tasks.md#apple-flinger)
-game.
-(You can find the TAR file with the APK and `.textproto` files
-[here](https://storage.googleapis.com/android_env-tasks/apple_flinger.tar.gz)
-and on the
-[example tasks](https://github.com/deepmind/android_env/blob/main/docs/example_tasks.md)
-page.)
+For instance, here is how you can run
+[`run_random_agent.py`](https://github.com/8bitmp3/android_env/blob/main/examples/run_random_agent.py)
+in a folder where you have your APK file, such as the
+[Apple Flinger](https://github.com/deepmind/android_env/blob/main/docs/example_tasks.md#apple-flinger)
+game from
+[Example tasks](https://github.com/deepmind/android_env/blob/main/docs/example_tasks.md).
+(The downloaded TAR file contains the APK file and `.textproto` definitions.)
 
 ```shell
 python3 run_random_agent.py \
@@ -113,60 +111,5 @@ python3 run_random_agent.py \
 --emulator_path=/Users/username/Library/Android/sdk/emulator/emulator \
 --adb_path=/Users/username/Library/Android/sdk/platform-tools/adb \
 --num_steps=1000 \
---task_path=/Users/username/<PATH-TO-APPLE-FLINGER-FILES>/apple_flinger_M_1_1.textproto
-```
-
-## Example with code: a random agent playing Droidfish (chess)
-
-Below is an example of a random agent playing chess in Droidfish using
-`droidfish_black_1.textproto` over 1000 steps (where `1` indicates the
-[level of difficulty](https://github.com/deepmind/android_env/blob/main/docs/example_tasks.md#droidfish)).
-You need to execute the Python code in a folder where you have the Droidfish APK
-file. (Download the Droidfish TAR file with the APK and `.textproto` files
-[here](https://storage.googleapis.com/android_env-tasks/droidfish.tar.gz)
-and on the
-[example tasks](https://github.com/deepmind/android_env/blob/main/docs/example_tasks.md)
-page.) Notice the use of `dm_env` - it's the
-[DeepMind RL Environment API](https://github.com/deepmind/dm_env).
-
-```python
-import android_env
-from dm_env import specs
-import numpy as np
-from typing import Dict
-
-env = android_env.load(
-    avd_name='my_avd',
-    android_avd_home='/Users/username/.android/avd',
-    android_sdk_root='/Users/username/Library/Android/sdk',
-    emulator_path='/Users/username/Library/Android/sdk/emulator/emulator',
-    adb_path='/Users/username/Library/Android/sdk/platform-tools/adb',
-    emulator_path='/Users/username/Library/Android/sdk/emulator/emulator',
-    adb_path='/Users/username/Library/Android/sdk/platform-tools/adb',
-    task_path='~/<path-to-droidfish-textproto>/droidfish_black_1.textproto'
-)
-
-action_spec = env.action_spec()
-
-def get_random_action() -> Dict[str, np.ndarray]:
-  """Returns a random AndroidEnv action."""
-  action = {}
-  for k, v in action_spec.items():
-    if isinstance(v, specs.DiscreteArray):
-      action[k] = np.random.randint(low=0, high=v.num_values, dtype=v.dtype)
-    else:
-      action[k] = np.random.random(size=v.shape).astype(v.dtype)
-  return action
-
-_ = env.reset()
-
-STEPS = 1000
-
-for step in range(STEPS):
-  action = get_random_action()
-  timestep = env.step(action=action)
-  reward = timestep.reward
-  print('Step {}, action: {}, reward: {}'.format(step, action, reward))
-
-env.close()
+--task_path=/Users/username/<PATH-TO-APP-TASK-FILES>/apple_flinger_M_1_1.textproto
 ```


### PR DESCRIPTION
Examples of what this PR proposes:

- Clearer steps to get started with a "Hello, World":

```
1. In Android Studio, create a virtual device by following this step-by-step
[guide](emulator_guide.md).
2. Follow the steps below to attach the AVD to your environment.
```
(with AVD defined)

- "Hello, World" tasks weren't easy to find, so this may help (with examples, like chess ♟️ , pong 🏓, etc):

```
* For ready-made example tasks provided with AndroidEnv, check out
  the [Available tasks](example_tasks.md), featuring Vokram (with Markov Decision
  Process (MDP)), Pong, DroidFish (a chess clone), Blockinger (a tetris clone),
  and more.

* See the [Tasks guide](tasks_guide.md) for details on features and
  capabilities of tasks, as well as how to create custom ones.
```

- Added a reference link to `android_env.load()`: https://github.com/deepmind/android_env/blob/main/android_env/loader.py

- Added the steps to find the AVD and SDK paths, because they're not easy to find. The AVD step is similar to the one mentioned in the AVD setup guide, but this may be overlooked by an inexperienced user.

```
For the AVD name and path, in Android Studio, go to **Tools** >
**AVD Manager**, right click on your virtual device, and select
**View Details**, where you will find the `avd_name` and its path.

For the Android SDK location, in Android Studio, go to **Preferences** >
**Appearance & Behavior** > **System Settings** > **Android SDKs** and note the
_Android SDK Location_. In the SDK folder, you will find `/emulator/emulator`
as well as the ADB path (`/platform-tools/adb`).
```

- "Example scripts" -> "Example RL agent scripts" + links to Python scripts for easier navigation:

```
## Example RL agent scripts

*   [`run_acme_agent.py`](https://github.com/deepmind/android_env/blob/main/examples/run_acme_agent.py):
    Runs a training loop with an [Acme](https://deepmind.com/research/publications/Acme)
    DQN agent, implemented in the popular DeepMind RL framework. This will
    require to install the [`acme`](https://github.com/deepmind/acme)
    dependency.
...
```

- Added an example with Apple Flinger and a random agent script, so that users can get started with scripts fast (tried and tested) - this is similar to Getting Started with [Retro Gym](https://retro.readthedocs.io/en/latest/getting_started.html#random-agent)::

```
For instance, here is how you can run `run_random_agent.py` in a folder where
you have your APK file, such as
the [Apple Flinger](https://github.com/deepmind/android_env/blob/main/docs/example_tasks.md#apple-flinger)
game.
(You can find the TAR file with the APK and `.textproto` files
[here](https://storage.googleapis.com/android_env-tasks/apple_flinger.tar.gz)
and on the
[example tasks](https://github.com/deepmind/android_env/blob/main/docs/example_tasks.md)
page.)

    ```shell
    python3 run_random_agent.py \
    --avd_name='my_avd',
    --android_avd_home=/Users/username/.android/avd \
    --android_sdk_root=/Users/username/Library/Android/sdk \
    --emulator_path=/Users/username/Library/Android/sdk/emulator/emulator \
    --adb_path=/Users/username/Library/Android/sdk/platform-tools/adb \
    --num_steps=1000 \
    --task_path=/Users/username/<PATH-TO-APPLE-FLINGER-FILES>/apple_flinger_M_1_1.textproto
    ```
```

- Added a new section - to help new users to get started fast with code/without command-lines. This is also kind of similar to Getting Started with [Retro Gym](https://retro.readthedocs.io/en/latest/getting_started.html#random-agent):

```
## Example with code: a random agent playing Droidfish (chess)

Below is an example of a random agent playing chess in Droidfish using
`droidfish_black_1.textproto` over 1000 steps (where `1` indicates the
[level of difficulty](https://github.com/deepmind/android_env/blob/main/docs/example_tasks.md#droidfish)).
You need to execute the Python code in a folder where you have the Droidfish APK
file. (Download the Droidfish TAR file with the APK and `.textproto` files
[here](https://storage.googleapis.com/android_env-tasks/droidfish.tar.gz)
and on the
[example tasks](https://github.com/deepmind/android_env/blob/main/docs/example_tasks.md)
page.) Notice the use of `dm_env` - it's the
[DeepMind RL Environment API](https://github.com/deepmind/dm_env).

    ```python
    import android_env
    from dm_env import specs
    import numpy as np
    from typing import Dict
    
    env = android_env.load(
        avd_name='my_avd',
        android_avd_home='/Users/username/.android/avd',
        android_sdk_root='/Users/username/Library/Android/sdk',
        emulator_path='/Users/username/Library/Android/sdk/emulator/emulator',
        adb_path='/Users/username/Library/Android/sdk/platform-tools/adb',
        emulator_path='/Users/username/Library/Android/sdk/emulator/emulator',
        adb_path='/Users/username/Library/Android/sdk/platform-tools/adb',
        task_path='~/<path-to-droidfish-textproto>/droidfish_black_1.textproto'
    )
    
    action_spec = env.action_spec()
    
    def get_random_action() -> Dict[str, np.ndarray]:
      """Returns a random AndroidEnv action."""
      action = {}
      for k, v in action_spec.items():
        if isinstance(v, specs.DiscreteArray):
          action[k] = np.random.randint(low=0, high=v.num_values, dtype=v.dtype)
        else:
          action[k] = np.random.random(size=v.shape).astype(v.dtype)
      return action
    
    _ = env.reset()
    
    STEPS = 1000
    
    for step in range(STEPS):
      action = get_random_action()
      timestep = env.step(action=action)
      reward = timestep.reward
      print('Step {}, action: {}, reward: {}'.format(step, action, reward))
    
    env.close()
    ```
```

- Minor grammar/typo fixes.

Hope this helps 👍 