### PR TITLE
typo: Change `python3 python3` to `python3`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ environment for Reinforcement Learning research:
 The easiest way to get AndroidEnv is with pip:
 
 ```shell
-$ python3 python3 -m pip install android-env
+$ python3 -m pip install android-env
 ```
 
 Please note that `/examples` are not included in this package.


### PR DESCRIPTION
# Summary

This change fixes a typo in the shell command to install the `pip` package for `android-env`.