### PR TITLE
Fixed typo issue on installation command using `git clone`

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Please note that `/examples` are not included in this package.
 Alternatively, you can clone the repository from git's `main` branch:
 
 ```shell
-$ git clone https://github.com/deepmind/android_env/
+$ git clone https://github.com/deepmind/android_env.git
 $ cd android_env
 $ python3 setup.py install
 ```


### PR DESCRIPTION
This change fixes a typo on installation command using `git clone`

If we want to clone the repository with command line.
we should use `.git` url path instead of `folder path`.
so i would like to fix type issue on installation command like below:

~`$ git clone https://github.com/deepmind/android_env/`~
`$ git clone https://github.com/deepmind/android_env.git`